### PR TITLE
Fix race condition in photo loading

### DIFF
--- a/SixPicks/Views/ContentView.swift
+++ b/SixPicks/Views/ContentView.swift
@@ -260,9 +260,11 @@ struct ContentView: View {
                     if let image = image {
                         DispatchQueue.main.async {
                             newSelectedPhotos.append(image)
+                            group.leave()
                         }
+                    } else {
+                        group.leave()
                     }
-                    group.leave()
                 }
             }
             


### PR DESCRIPTION
## Summary
- ensure the dispatch group waits until photos have been appended before notifying

## Testing
- `swiftc -parse SixPicks/Views/ContentView.swift`
- `find SixPicks -name '*.swift' -print | xargs swiftc -parse`

------
https://chatgpt.com/codex/tasks/task_e_683f3d9a33c0833192799fa572c2deef